### PR TITLE
(Revised) Camera Now Adjusts on Update Call

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -214,7 +214,7 @@ GameObject:
   - component: {fileID: 229084581}
   m_Layer: 0
   m_Name: Flatened Spartan
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -370,8 +370,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d6cfd76844bd85a44a50fa1707dd45fa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  health: 100
-  maxHealth: 100
   damage: 10
   speed: 10
   jumpPower: 30
@@ -437,6 +435,7 @@ GameObject:
   - component: {fileID: 519420032}
   - component: {fileID: 519420031}
   - component: {fileID: 519420029}
+  - component: {fileID: 519420033}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -518,6 +517,19 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &519420033
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5a4c0850f981abf438a81b803ac390b0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  minimumZoom: 7
 --- !u!1 &522941848
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CameraAdjustment.cs
+++ b/Assets/Scripts/CameraAdjustment.cs
@@ -83,8 +83,8 @@ public class CameraAdjustment : MonoBehaviour
         float xMinimumZoom = Mathf.Ceil(xDistance / 4);
         float yMinimumZoom = Mathf.Ceil(yDistance * 2 / 3);
         
-        if (Mathf.Max(xMinimumZoom, yMinimumZoom) < minimumZoom){
-            yCenter += Mathf.Max(xMinimumZoom, yMinimumZoom) / 2;
+        if (yDistance <= 5f){
+            yCenter += 3f / (1 + yDistance);
         }
 
         Vector3 center = new Vector3(xCenter, yCenter, -1f);

--- a/Assets/Scripts/CameraAdjustment.cs
+++ b/Assets/Scripts/CameraAdjustment.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
@@ -20,21 +21,11 @@ public class CameraAdjustment : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        playerArray = GameObject.FindGameObjectsWithTag("Player");
-
         m_MainCamera = Camera.main;
         m_MainCamera.enabled = true;
 
         UpdateLimits();
         SetCamera();
-    }
-
-    private void OnPlayerJoinedMessage() {
-        playerArray = GameObject.FindGameObjectsWithTag("Player");
-    }
-
-    private void OnPlayerLeftMessage() {
-        playerArray = GameObject.FindGameObjectsWithTag("Player");
     }
 
     // Update is called once per frame
@@ -58,6 +49,7 @@ public class CameraAdjustment : MonoBehaviour
     void UpdateLimits()
     {
         InitializeLimits();
+        playerArray = GameObject.FindGameObjectsWithTag("Player");
 
         foreach (GameObject player in playerArray) // Compares limits to all player positions
         {
@@ -88,15 +80,14 @@ public class CameraAdjustment : MonoBehaviour
         float xDistance = Mathf.Abs(leftLimit - rightLimit);
         float yDistance = Mathf.Abs(downLimit - upLimit);
 
-        if (yDistance <= 3f)
-        {
-            yDistance += 4f;
+        float xMinimumZoom = Mathf.Ceil(xDistance / 4);
+        float yMinimumZoom = Mathf.Ceil(yDistance * 2 / 3);
+        
+        if (Mathf.Max(xMinimumZoom, yMinimumZoom) < minimumZoom){
+            yCenter += Mathf.Max(xMinimumZoom, yMinimumZoom) / 2;
         }
 
         Vector3 center = new Vector3(xCenter, yCenter, -1f);
-
-        float xMinimumZoom = Mathf.Ceil(xDistance / 4);
-        float yMinimumZoom = Mathf.Ceil(yDistance * 2 / 3);
 
         Camera.main.transform.position = center;
 
@@ -125,16 +116,14 @@ public class CameraAdjustment : MonoBehaviour
         float xDistance = Mathf.Abs(leftLimit - rightLimit);
         float yDistance = Mathf.Abs(downLimit - upLimit);
 
-        // This is so if all players are around the same y-value, the camera shifts upwards because player movement tends
-        // to favor up than down for better visibility.
-        if (yDistance <= 3f){
-            yDistance += 4f;
+        float xMinimumZoom = Mathf.Ceil(xDistance / 4);
+        float yMinimumZoom = Mathf.Ceil(yDistance * 2 / 3);
+        
+        if (yDistance <= 5f){
+            yCenter += 3f / (1 + yDistance);
         }
 
         Vector3 center = new Vector3(xCenter, yCenter, -1f);
-
-        float xMinimumZoom = Mathf.Ceil(xDistance / 4);
-        float yMinimumZoom = Mathf.Ceil(yDistance * 2 / 3);
 
         Camera.main.transform.position = center;
 

--- a/Assets/Scripts/CameraAdjustment.cs
+++ b/Assets/Scripts/CameraAdjustment.cs
@@ -33,6 +33,10 @@ public class CameraAdjustment : MonoBehaviour
         playerArray = GameObject.FindGameObjectsWithTag("Player");
     }
 
+    private void OnPlayerLeftMessage() {
+        playerArray = GameObject.FindGameObjectsWithTag("Player");
+    }
+
     // Update is called once per frame
     void Update()
     {

--- a/Assets/Scripts/CameraAdjustment.cs
+++ b/Assets/Scripts/CameraAdjustment.cs
@@ -11,6 +11,7 @@ public class CameraAdjustment : MonoBehaviour
     protected float rightLimit;
 
     protected GameObject[] playerArray = null;
+
     protected Camera m_MainCamera;
     [SerializeField] protected float minimumZoom = 7f;
 
@@ -19,25 +20,24 @@ public class CameraAdjustment : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        splitScreenBool = GameObject.Find("PlayerInputManager").GetComponent<PlayerInputManager>().splitScreen;
-        if (!splitScreenBool){
-            playerArray = GameObject.FindGameObjectsWithTag("Player");
+        playerArray = GameObject.FindGameObjectsWithTag("Player");
 
-            m_MainCamera = Camera.main;
-            m_MainCamera.enabled = true;
+        m_MainCamera = Camera.main;
+        m_MainCamera.enabled = true;
 
-            UpdateLimits();
-            SetCamera();
-        }
+        UpdateLimits();
+        SetCamera();
+    }
+
+    private void OnPlayerJoinedMessage() {
+        playerArray = GameObject.FindGameObjectsWithTag("Player");
     }
 
     // Update is called once per frame
     void Update()
     {
-        if (!splitScreenBool){
-            UpdateLimits();
-            UpdateCamera();
-        }
+        UpdateLimits();
+        UpdateCamera();
     }
 
     // Floats can't be null, so I'm using a random (the first) player to initialize them

--- a/Assets/Scripts/CameraAdjustment.cs
+++ b/Assets/Scripts/CameraAdjustment.cs
@@ -24,15 +24,21 @@ public class CameraAdjustment : MonoBehaviour
         m_MainCamera = Camera.main;
         m_MainCamera.enabled = true;
 
-        UpdateLimits();
-        SetCamera();
+        InitializeLimits();
+
+        if (GameObject.FindGameObjectsWithTag("Player") != null){
+            UpdateLimits();
+            SetCamera();
+        }
     }
 
     // Update is called once per frame
     void Update()
     {
-        UpdateLimits();
-        UpdateCamera();
+        if (GameObject.FindGameObjectsWithTag("Player") != null){
+            UpdateLimits();
+            SetCamera();
+        }
     }
 
     // Floats can't be null, so I'm using a random (the first) player to initialize them
@@ -48,7 +54,6 @@ public class CameraAdjustment : MonoBehaviour
     // Updates the limit variables to get the new camera center and size needed to display all players.
     void UpdateLimits()
     {
-        InitializeLimits();
         playerArray = GameObject.FindGameObjectsWithTag("Player");
 
         foreach (GameObject player in playerArray) // Compares limits to all player positions


### PR DESCRIPTION
Revision: CameraAdjustment now does not do anything if there are no players in the scene.

The way in which the camera's list of players to keep track of has been set to update in Update().

Additionally, the centering of the camera when players are vertically near is raised to be biased towards upwards visibility.